### PR TITLE
[FIX] working without autogenerate

### DIFF
--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -31,7 +31,7 @@ docker run \
   <% for(var option in logConfig.opts) { %>--log-opt <%= option %>=<%= logConfig.opts[option] %> <% } %>\
   <% for(var volume in volumes) { %>-v <%= volume %>:<%= volumes[volume] %> <% } %>\
   <% for(var args in docker.args) { %> <%= docker.args[args] %> <% } %>\
-  <% if(typeof sslConfig.autogenerate === "object")  { %> \
+  <% if(sslConfig && typeof sslConfig.autogenerate === "object")  { %> \
     -e "VIRTUAL_HOST=$HOSTNAME" \
     -e "LETSENCRYPT_HOST=<%= sslConfig.autogenerate.domains %>" \
     -e "LETSENCRYPT_EMAIL=<%= sslConfig.autogenerate.email %>" \

--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -22,7 +22,11 @@ echo "Pulled <%= docker.image %>"
 docker run \
   -d \
   --restart=always \
+  <% if(sslConfig && typeof sslConfig.autogenerate === "object")  { %> \
   --expose=80 \
+  <% } else { %> \
+  --publish=$PORT:80 \
+  <% } %> \
   --volume=$BUNDLE_PATH:/bundle \
   --hostname="$HOSTNAME-$APPNAME" \
   --env-file=$ENV_FILE \


### PR DESCRIPTION
This changes were not completely tested without any ssl config block or without ssl.autogenerate config block.

Two problems were fixed:

- It was throwing an error, if there is no ssl config block.
- It was not publishing PORT 80, when there was no ssl config block and validation of deployment failed.